### PR TITLE
Transition conditions

### DIFF
--- a/StateMachine/LSStateMachine.h
+++ b/StateMachine/LSStateMachine.h
@@ -9,6 +9,7 @@
 @property (nonatomic, strong) NSString *initialState;
 - (void)addState:(NSString *)state;
 - (void)when:(NSString *)eventName transitionFrom:(NSString *)from to:(NSString *)to;
+- (void)when:(NSString *)eventName transitionFrom:(NSString *)from to:(NSString *)to if:(LSStateMachineTransitionCondition)condition;
 - (LSEvent *)eventWithName:(NSString *)name;
 
 - (void)before:(NSString *)eventName do:(LSStateMachineTransitionCallback)callback;

--- a/StateMachine/LSStateMachine.m
+++ b/StateMachine/LSStateMachine.m
@@ -30,8 +30,13 @@ void * LSStateMachineDefinitionKey = &LSStateMachineDefinitionKey;
 }
 
 - (void)when:(NSString *)eventName transitionFrom:(NSString *)from to:(NSString *)to; {
+    [self when:eventName transitionFrom:from to:to if:nil];
+}
+
+- (void)when:(NSString *)eventName transitionFrom:(NSString *)from to:(NSString *)to if:(LSStateMachineTransitionCondition)condition; {
     LSEvent *event = [self eventWithName:eventName];
     LSTransition *transition = [LSTransition transitionFrom:from to:to];
+    transition.condition = condition;
     if (!event) {
         event = [LSEvent eventWithName:eventName transitions:[NSSet setWithObject:transition]];
     } else {
@@ -44,7 +49,7 @@ void * LSStateMachineDefinitionKey = &LSStateMachineDefinitionKey;
 - (NSString *)nextStateFrom:(NSString *)from forEvent:(NSString *)eventName {
     LSEvent *event = [self eventWithName:eventName];
     for (LSTransition *transition in event.transitions) {
-        if ([transition.from isEqualToString:from]) {
+        if ([transition.from isEqualToString:from] && [transition checkCondition]) {
             return transition.to;
         }
     }

--- a/StateMachine/LSStateMachineTypedefs.h
+++ b/StateMachine/LSStateMachineTypedefs.h
@@ -2,5 +2,6 @@
 #define StateMachine_LSStateMachineTypedefs_h
 
 typedef void(^LSStateMachineTransitionCallback)(id object);
+typedef BOOL(^LSStateMachineTransitionCondition)(id object);
 
 #endif

--- a/StateMachine/LSTransition.h
+++ b/StateMachine/LSTransition.h
@@ -1,8 +1,11 @@
 #import <Foundation/Foundation.h>
+#import "LSStateMachineTypedefs.h"
 
 @interface LSTransition : NSObject
 + (id)transitionFrom:(NSString *)from to:(NSString *)to;
 - (id)initFrom:(NSString *)from to:(NSString *)to;
+- (BOOL)checkCondition;
 @property (nonatomic, copy, readonly) NSString *from;
 @property (nonatomic, copy, readonly) NSString *to;
+@property (nonatomic, copy) LSStateMachineTransitionCondition condition;
 @end

--- a/StateMachine/LSTransition.m
+++ b/StateMachine/LSTransition.m
@@ -13,6 +13,15 @@
     return self;
 }
 
+- (BOOL)checkCondition
+{
+    if (!self.condition)
+    {
+        return YES;
+    }
+    return self.condition(self);
+}
+
 - (BOOL)isEqual:(id)object {
     if (self == object) {
         return YES;

--- a/StateMachineTests/LSStateMachineSpec.m
+++ b/StateMachineTests/LSStateMachineSpec.m
@@ -101,6 +101,30 @@ describe(@"addTransition", ^{
             });
         });
 
+        describe(@"transition conditions", ^{
+            it(@"should be able to accept a condition for the transition", ^{
+                [sm when:@"activate" transitionFrom:@"pending" to:@"active" if:^BOOL(id object) {
+                    return YES;
+                }];
+
+                [[sm.events should] haveCountOf:1];
+                LSEvent *event = [sm.events anyObject];
+
+                [[event.transitions should] haveCountOf:1];
+                LSTransition *transition = [event.transitions anyObject];
+
+                [transition.condition shouldNotBeNil];
+                [[theValue(transition.condition(nil)) should] equal:theValue(YES)];
+            });
+
+            it(@"should not transition if condition is negative", ^{
+                [sm when:@"activate" transitionFrom:@"pending" to:@"active" if:^BOOL(id object) {
+                    return NO;
+                }];
+
+                [[sm nextStateFrom:@"pending" forEvent:@"activate"] shouldBeNil];
+            });
+        });
     });
 });
 

--- a/StateMachineTests/LSTransitionSpec.m
+++ b/StateMachineTests/LSTransitionSpec.m
@@ -13,4 +13,8 @@ it(@"should have a source or 'from' state", ^{
 it(@"should have a final or 'to' state", ^{
     [[transition.to should] equal:@"active"];
 });
+
+it(@"should have an empty condition block", ^{
+    [transition.condition shouldBeNil];
+});
 SPEC_END


### PR DESCRIPTION
I've added the possibility to provide a special condition for a transition to be valid. This is similar to what the ruby state_machine gem also provides. I added it as a third optional parameter called "if" with a new block typedef that returns a BOOL.

Example:

```
[sm when:@"activate" transitionFrom:@"pending" to:@"active" if:^BOOL(LSStateMachine *stateMachine) {
    // Run your custom condition check here.
    if (YES) {
       return YES;
    }
    return NO;
}];
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/luisobo/statemachine/1)

<!-- Reviewable:end -->
