### PR TITLE
Camel case should be permitted in state names and event names

### DIFF
--- a/StateMachine.xcodeproj/project.pbxproj
+++ b/StateMachine.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8D6F730316DC962D00A5A8F4 /* NSString+Capitalize.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6F730216DC962D00A5A8F4 /* NSString+Capitalize.m */; };
+		8DF481D617125AB600B4B5F9 /* NSString+CapitalizeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF481D517125AB600B4B5F9 /* NSString+CapitalizeSpec.m */; };
 		A001F2031630DB10002AEC31 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2021630DB10002AEC31 /* Foundation.framework */; };
 		A001F2121630DB11002AEC31 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2111630DB11002AEC31 /* SenTestingKit.framework */; };
 		A001F2151630DB11002AEC31 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2021630DB10002AEC31 /* Foundation.framework */; };
@@ -51,6 +52,7 @@
 		2BBE849696034C15B9965570 /* Pods-StateMachineTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StateMachineTests.xcconfig"; path = "Pods/Pods-StateMachineTests.xcconfig"; sourceTree = SOURCE_ROOT; };
 		8D6F730116DC962D00A5A8F4 /* NSString+Capitalize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Capitalize.h"; sourceTree = "<group>"; };
 		8D6F730216DC962D00A5A8F4 /* NSString+Capitalize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Capitalize.m"; sourceTree = "<group>"; };
+		8DF481D517125AB600B4B5F9 /* NSString+CapitalizeSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+CapitalizeSpec.m"; sourceTree = "<group>"; };
 		A001F1FF1630DB10002AEC31 /* libStateMachine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStateMachine.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A001F2021630DB10002AEC31 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A001F2061630DB10002AEC31 /* StateMachine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StateMachine-Prefix.pch"; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				A001F21A1630DB11002AEC31 /* Supporting Files */,
+				8DF481D517125AB600B4B5F9 /* NSString+CapitalizeSpec.m */,
 				A001F2201630DB11002AEC31 /* StateMachineSpec.m */,
 				A066CFEE163D850B0061797C /* LSStateMachineSpec.m */,
 				A066CFF2163D8FF50061797C /* LSEventSpec.m */,
@@ -307,6 +310,7 @@
 				A066CFEF163D850B0061797C /* LSStateMachineSpec.m in Sources */,
 				A066CFF3163D8FF50061797C /* LSEventSpec.m in Sources */,
 				A066CFF8163D94070061797C /* LSTransitionSpec.m in Sources */,
+				8DF481D617125AB600B4B5F9 /* NSString+CapitalizeSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StateMachine.xcodeproj/project.pbxproj
+++ b/StateMachine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8D6F730316DC962D00A5A8F4 /* NSString+Capitalize.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6F730216DC962D00A5A8F4 /* NSString+Capitalize.m */; };
 		A001F2031630DB10002AEC31 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2021630DB10002AEC31 /* Foundation.framework */; };
 		A001F2121630DB11002AEC31 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2111630DB11002AEC31 /* SenTestingKit.framework */; };
 		A001F2151630DB11002AEC31 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A001F2021630DB10002AEC31 /* Foundation.framework */; };
@@ -48,6 +49,8 @@
 /* Begin PBXFileReference section */
 		1E77622C3F81426C94A2727E /* libPods-StateMachineTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StateMachineTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2BBE849696034C15B9965570 /* Pods-StateMachineTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StateMachineTests.xcconfig"; path = "Pods/Pods-StateMachineTests.xcconfig"; sourceTree = SOURCE_ROOT; };
+		8D6F730116DC962D00A5A8F4 /* NSString+Capitalize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Capitalize.h"; sourceTree = "<group>"; };
+		8D6F730216DC962D00A5A8F4 /* NSString+Capitalize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Capitalize.m"; sourceTree = "<group>"; };
 		A001F1FF1630DB10002AEC31 /* libStateMachine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStateMachine.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A001F2021630DB10002AEC31 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A001F2061630DB10002AEC31 /* StateMachine-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StateMachine-Prefix.pch"; sourceTree = "<group>"; };
@@ -137,6 +140,8 @@
 				A066CFF9163D941D0061797C /* LSTransition.h */,
 				A066CFFA163D941D0061797C /* LSTransition.m */,
 				A0C8CA39163DE6F50027B912 /* LSStateMachineMacros.h */,
+				8D6F730116DC962D00A5A8F4 /* NSString+Capitalize.h */,
+				8D6F730216DC962D00A5A8F4 /* NSString+Capitalize.m */,
 				A05206BC164363FF00D5E855 /* LSStateMachineDynamicAdditions.h */,
 				A05206BD164363FF00D5E855 /* LSStateMachineDynamicAdditions.m */,
 				A0BBF3581648C2D600DED3C2 /* LSStateMachineTypedefs.h */,
@@ -290,6 +295,7 @@
 				A066CFF6163D90190061797C /* LSEvent.m in Sources */,
 				A066CFFB163D941D0061797C /* LSTransition.m in Sources */,
 				A05206BE164363FF00D5E855 /* LSStateMachineDynamicAdditions.m in Sources */,
+				8D6F730316DC962D00A5A8F4 /* NSString+Capitalize.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StateMachine/LSStateMachineDynamicAdditions.m
+++ b/StateMachine/LSStateMachineDynamicAdditions.m
@@ -1,3 +1,5 @@
+#import "NSString+Capitalize.h"
+
 #import "LSStateMachineDynamicAdditions.h"
 #import "LSStateMachine.h"
 #import "LSEvent.h"
@@ -42,7 +44,7 @@ void LSStateMachineInitializeInstance(id self, SEL _cmd) {
 // This is the implementation of all the is<StateName> instance methods
 BOOL LSStateMachineCheckState(id self, SEL _cmd) {
     NSString *currentState = [self performSelector:@selector(state)];
-    NSString *query = [[NSStringFromSelector(_cmd) substringFromIndex:2] lowercaseString];
+    NSString *query = [[NSStringFromSelector(_cmd) substringFromIndex:2] initialLowercase];
     return [query isEqualToString:currentState];
 }
 
@@ -50,7 +52,7 @@ BOOL LSStateMachineCheckState(id self, SEL _cmd) {
 BOOL LSStateMachineCheckCanTransition(id self, SEL _cmd) {
     LSStateMachine *sm = [[self class] performSelector:@selector(stateMachine)];
     NSString *currentState = [self performSelector:@selector(state)];
-    NSString *query = [[NSStringFromSelector(_cmd) substringFromIndex:3] lowercaseString];
+    NSString *query = [[NSStringFromSelector(_cmd) substringFromIndex:3] initialLowercase];
     NSString *nextState = [sm nextStateFrom:currentState forEvent:query];
     return nextState != nil;
 }
@@ -61,12 +63,12 @@ void LSStateMachineInitializeClass(Class klass) {
     for (LSEvent *event in sm.events) {
         class_addMethod(klass, NSSelectorFromString(event.name), (IMP) LSStateMachineTriggerEvent, "i@:");
         
-        NSString *transitionQueryMethodName = [NSString stringWithFormat:@"can%@", [event.name capitalizedString]];
+        NSString *transitionQueryMethodName = [NSString stringWithFormat:@"can%@", [event.name initialCapital]];
         class_addMethod(klass, NSSelectorFromString(transitionQueryMethodName), (IMP) LSStateMachineCheckCanTransition, "i@:");
     }
     
     for (NSString *state in sm.states) {
-        NSString *queryMethodName = [NSString stringWithFormat:@"is%@", [state capitalizedString]];
+        NSString *queryMethodName = [NSString stringWithFormat:@"is%@", [state initialCapital]];
         class_addMethod(klass, NSSelectorFromString(queryMethodName), (IMP) LSStateMachineCheckState, "i@:");
     }
     class_addMethod(klass, @selector(initializeStateMachine), (IMP) LSStateMachineInitializeInstance, "v@:");

--- a/StateMachine/NSString+Capitalize.h
+++ b/StateMachine/NSString+Capitalize.h
@@ -1,11 +1,3 @@
-//
-//  NSString+Capitalize.h
-//  StateMachine
-//
-//  Created by Steven Luscher on 2013-02-25.
-//  Copyright (c) 2013 Luis Solano Bonet. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 
 @interface NSString (Capitalize)

--- a/StateMachine/NSString+Capitalize.h
+++ b/StateMachine/NSString+Capitalize.h
@@ -1,0 +1,14 @@
+//
+//  NSString+Capitalize.h
+//  StateMachine
+//
+//  Created by Steven Luscher on 2013-02-25.
+//  Copyright (c) 2013 Luis Solano Bonet. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (Capitalize)
+- (NSString *)initialCapital;
+- (NSString *)initialLowercase;
+@end

--- a/StateMachine/NSString+Capitalize.m
+++ b/StateMachine/NSString+Capitalize.m
@@ -1,0 +1,22 @@
+//
+//  NSString+Capitalize.m
+//  StateMachine
+//
+//  Created by Steven Luscher on 2013-02-25.
+//  Copyright (c) 2013 Luis Solano Bonet. All rights reserved.
+//
+
+#import "NSString+Capitalize.h"
+
+@implementation NSString (Capitalize)
+- (NSString *)initialCapital
+{
+    NSString *firstLetter = [self substringToIndex:1];
+    return [self stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[firstLetter uppercaseString]];
+}
+- (NSString *)initialLowercase
+{
+    NSString *firstLetter = [self substringToIndex:1];
+    return [self stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[firstLetter lowercaseString]];
+}
+@end

--- a/StateMachine/NSString+Capitalize.m
+++ b/StateMachine/NSString+Capitalize.m
@@ -1,11 +1,3 @@
-//
-//  NSString+Capitalize.m
-//  StateMachine
-//
-//  Created by Steven Luscher on 2013-02-25.
-//  Copyright (c) 2013 Luis Solano Bonet. All rights reserved.
-//
-
 #import "NSString+Capitalize.h"
 
 @implementation NSString (Capitalize)

--- a/StateMachineTests/LSStateMachineSpec.m
+++ b/StateMachineTests/LSStateMachineSpec.m
@@ -14,25 +14,25 @@ describe(@"initialState", ^{
     });
     context(@"when setting the initial state", ^{
         it(@"should set that state as default", ^{
-            sm.initialState = @"pending";
+            sm.initialState = @"pendingActivation";
             
-            [[sm.initialState should] equal:@"pending"]; // Over testing? Probably
+            [[sm.initialState should] equal:@"pendingActivation"]; // Over testing? Probably
         });
         context(@"when the state being set as initial does not exist in the state machine", ^{
             it(@"should also add it", ^{
-                sm.initialState = @"pending";
+                sm.initialState = @"pendingActivation";
                 
-                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pending"]]];
+                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pendingActivation"]]];
             });
         });
         context(@"when the state being set as initial is already defined in the state machine", ^{
             beforeEach(^{
-                [sm addState:@"pending"];
+                [sm addState:@"pendingActivation"];
             });
             it(@"should no read it", ^{
-                sm.initialState = @"pending";
+                sm.initialState = @"pendingActivation";
                 
-                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pending"]]];
+                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pendingActivation"]]];
             });
         });
     });
@@ -46,34 +46,34 @@ describe(@"addState", ^{
     context(@"after adding one state", ^{
         context(@"when the SM has no initial state", ^{
             it(@"should contain that state", ^{
-                [sm addState:@"pending"];
+                [sm addState:@"pendingActivation"];
                 
-                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pending"]]];
+                [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pendingActivation"]]];
             });
             it(@"should set that state as the initial", ^{
-                [sm addState:@"pending"];
+                [sm addState:@"pendingActivation"];
                 
-                [[sm.initialState should] equal:@"pending"];
+                [[sm.initialState should] equal:@"pendingActivation"];
             });
         });
     });
     
     context(@"after adding two states", ^{
         beforeEach(^{
-            [sm addState:@"pending"];
+            [sm addState:@"pendingActivation"];
             [sm addState:@"active"];
         });
         it(@"should contain those states", ^{
-            [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pending", @"active"]]];
+            [[sm.states should] equal:[[NSSet alloc] initWithArray:@[@"pendingActivation", @"active"]]];
         });
     });
     
     context(@"after adding the same state twice", ^{
         it(@"should have no effect", ^{
-            [sm addState:@"pending"];
-            [sm addState:@"pending"];
+            [sm addState:@"pendingActivation"];
+            [sm addState:@"pendingActivation"];
             
-            [[sm.states should] equal:[NSSet setWithObject:@"pending"]];
+            [[sm.states should] equal:[NSSet setWithObject:@"pendingActivation"]];
         });
     });
 });
@@ -82,18 +82,18 @@ describe(@"addTransition", ^{
     it(@"should have no transitions by default", ^{
         [[sm.events should] equal: [[NSSet alloc] init]];
     });
-    context(@"given a state machine with the states 'pending' and 'active'", ^{
+    context(@"given a state machine with the states 'pendingActivation' and 'active'", ^{
         beforeEach(^{
-            [sm addState:@"pending"];
+            [sm addState:@"pendingActivation"];
             [sm addState:@"active"];
         });
-        describe(@"after adding a transition from 'pending' to 'active' called activate", ^{
+        describe(@"after adding a transition from 'pendingActivation' to 'active' called activate", ^{
             describe(@"when the SM has no events previously defined", ^{
                 it(@"should contain one event", ^{
-                    [sm when:@"activate" transitionFrom:@"pending" to:@"active"];
+                    [sm when:@"activate" transitionFrom:@"pendingActivation" to:@"active"];
                     
                     [[sm.events should] haveCountOf:1];
-                    NSSet *transitions = [NSSet setWithObject:[LSTransition transitionFrom:@"pending" to:@"active"]];
+                    NSSet *transitions = [NSSet setWithObject:[LSTransition transitionFrom:@"pendingActivation" to:@"active"]];
                     LSEvent * event = [LSEvent eventWithName:@"activate"
                                                  transitions:transitions];
                     [[sm.events should] contain:event];
@@ -107,15 +107,15 @@ describe(@"addTransition", ^{
 describe(@"nextStateFrom:forEvent:", ^{
     context(@"given a SM with two states and one transition", ^{
         beforeEach(^{
-            [sm addState:@"pending"];
+            [sm addState:@"pendingActivation"];
             [sm addState:@"active"];
             
-            [sm when:@"activate" transitionFrom:@"pending" to:@"active"];
+            [sm when:@"activate" transitionFrom:@"pendingActivation" to:@"active"];
         });
         
         context(@"when asking for the next state of a valid transition", ^{
             it(@"should return the correct state", ^{
-                [sm nextStateFrom:@"pending" forEvent:@"activate"];
+                [sm nextStateFrom:@"pendingActivation" forEvent:@"activate"];
             });
         });
     });
@@ -129,12 +129,12 @@ describe(@"eventWithName:", ^{
     });
     context(@"for a defined event", ^{
         beforeEach(^{
-            [sm addState:@"pending"];
+            [sm addState:@"pendingActivation"];
             [sm addState:@"active"];
             [sm addState:@"suspended"];
             [sm addState:@"terminated"];
             
-            [sm when:@"activate" transitionFrom:@"pending" to:@"active"];
+            [sm when:@"activate" transitionFrom:@"pendingActivation" to:@"active"];
             [sm when:@"suspend" transitionFrom:@"active" to:@"suspended"];
             [sm when:@"unsuspend" transitionFrom:@"suspended" to:@"active"];
             [sm when:@"terminate" transitionFrom:@"active" to:@"terminated"];
@@ -143,7 +143,7 @@ describe(@"eventWithName:", ^{
         it(@"should return that event", ^{
             LSEvent *active = [sm eventWithName:@"activate"];
             [[active.name should] equal:@"activate"];
-            [[active.transitions should] equal:[NSSet setWithObject:[LSTransition transitionFrom:@"pending" to:@"active"]]];
+            [[active.transitions should] equal:[NSSet setWithObject:[LSTransition transitionFrom:@"pendingActivation" to:@"active"]]];
             
             LSEvent *suspend = [sm eventWithName:@"suspend"];
             [[suspend.name should] equal:@"suspend"];

--- a/StateMachineTests/LSTransitionSpec.m
+++ b/StateMachineTests/LSTransitionSpec.m
@@ -4,10 +4,10 @@
 SPEC_BEGIN(LSTransitionSpec)
 __block LSTransition *transition = nil;
 beforeEach(^{
-    transition = [[LSTransition alloc] initFrom:@"pending" to:@"active"];
+    transition = [[LSTransition alloc] initFrom:@"pendingActivation" to:@"active"];
 });
 it(@"should have a source or 'from' state", ^{
-    [[transition.from should] equal:@"pending"];
+    [[transition.from should] equal:@"pendingActivation"];
 });
 
 it(@"should have a final or 'to' state", ^{

--- a/StateMachineTests/NSString+CapitalizeSpec.m
+++ b/StateMachineTests/NSString+CapitalizeSpec.m
@@ -1,0 +1,35 @@
+#import "Kiwi.h"
+#import "NSString+Capitalize.h"
+
+SPEC_BEGIN(NSStringCapitalizeSpec)
+context(@"given a test battery of strings", ^{
+    __block NSString *lowercaseString = nil;
+    __block NSString *uppercaseString = nil;
+    __block NSString *mixedCaseString = nil;
+    __block NSString *inverseMixedCaseString = nil;
+    beforeEach(^{
+        lowercaseString = @"lowercase";
+        uppercaseString = @"UPPERCASE";
+        mixedCaseString = @"MiXeDcAsE";
+        inverseMixedCaseString = @"mIxEdCaSe";
+    });
+    
+    describe(@"initialCapital", ^{
+        it(@"should upcase only the first character of each string", ^{
+            [[[lowercaseString initialCapital] should] equal: @"Lowercase"];
+            [[[uppercaseString initialCapital] should] equal: @"UPPERCASE"];
+            [[[mixedCaseString initialCapital] should] equal: @"MiXeDcAsE"];
+            [[[inverseMixedCaseString initialCapital] should] equal: @"MIxEdCaSe"];
+        });
+    });
+    
+    describe(@"initialLowercase", ^{
+        it(@"should downcase only the first character of each string", ^{
+            [[[lowercaseString initialLowercase] should] equal: @"lowercase"];
+            [[[uppercaseString initialLowercase] should] equal: @"uPPERCASE"];
+            [[[mixedCaseString initialLowercase] should] equal: @"miXeDcAsE"];
+            [[[inverseMixedCaseString initialLowercase] should] equal: @"mIxEdCaSe"];
+        });
+    });
+});
+SPEC_END

--- a/StateMachineTests/StateMachineSpec.m
+++ b/StateMachineTests/StateMachineSpec.m
@@ -14,7 +14,7 @@
 - (BOOL)unsuspend;
 - (BOOL)terminate;
 
-- (BOOL)isPending;
+- (BOOL)isPendingActivation;
 - (BOOL)isActive;
 - (BOOL)isSuspended;
 - (BOOL)isTerminated;
@@ -27,18 +27,18 @@
 @implementation Subscription
 
 STATE_MACHINE(^(LSStateMachine *sm) {
-    sm.initialState = @"pending";
+    sm.initialState = @"pendingActivation";
     
-    [sm addState:@"pending"];
+    [sm addState:@"pendingActivation"];
     [sm addState:@"active"];
     [sm addState:@"suspended"];
     [sm addState:@"terminated"];
     
-    [sm when:@"activate"  transitionFrom:@"pending"   to:@"active"];
-    [sm when:@"suspend"   transitionFrom:@"active"    to:@"suspended"];
-    [sm when:@"unsuspend" transitionFrom:@"suspended" to:@"active"];
-    [sm when:@"terminate" transitionFrom:@"active"    to:@"terminated"];
-    [sm when:@"terminate" transitionFrom:@"suspended" to:@"terminated"];
+    [sm when:@"activate"  transitionFrom:@"pendingActivation" to:@"active"];
+    [sm when:@"suspend"   transitionFrom:@"active"            to:@"suspended"];
+    [sm when:@"unsuspend" transitionFrom:@"suspended"         to:@"active"];
+    [sm when:@"terminate" transitionFrom:@"active"            to:@"terminated"];
+    [sm when:@"terminate" transitionFrom:@"suspended"         to:@"terminated"];
     
     [sm before:@"terminate" do:^(Subscription *subscription){
         subscription.terminatedAt = [NSDate dateWithTimeIntervalSince1970:123123123];
@@ -71,14 +71,14 @@ context(@"given a Subscripion", ^{
     });
     
     describe(@"default state", ^{
-        it(@"should be 'pending'", ^{
-            [[sut.state should] equal: @"pending"];
+        it(@"should be 'pendingActivation'", ^{
+            [[sut.state should] equal: @"pendingActivation"];
         });
     });
     
     describe(@"valid transitions", ^{
         describe(@"activate", ^{
-            describe(@"from 'pending'", ^{
+            describe(@"from 'pendingActivation'", ^{
                 it(@"should change the state to 'active'", ^{
                     [sut activate];
                     
@@ -164,22 +164,22 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"terminate", ^{
-            describe(@"from pending", ^{
+            describe(@"from pendingActivation", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut terminate]) should] beNo];
                 });
                 it(@"should not change the state", ^{
-                    [[sut.state should] equal:@"pending"];
+                    [[sut.state should] equal:@"pendingActivation"];
                 });
             });
         });
     });
     
     describe(@"checking if it's in a state", ^{
-        describe(@"isPending", ^{
-            context(@"when 'pending'", ^{
+        describe(@"isPendingActivation", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return YES", ^{
-                    [[theValue([sut isPending]) should] beYes];
+                    [[theValue([sut isPendingActivation]) should] beYes];
                 });
             });
             context(@"when 'active'", ^{
@@ -187,7 +187,7 @@ context(@"given a Subscripion", ^{
                     [sut activate];
                 });
                 it(@"should return NO", ^{
-                    [[theValue([sut isPending]) should] beNo];
+                    [[theValue([sut isPendingActivation]) should] beNo];
                 });
             });
             context(@"when 'suspended'", ^{
@@ -196,7 +196,7 @@ context(@"given a Subscripion", ^{
                     [sut suspend];
                 });
                 it(@"should return NO", ^{
-                    [[theValue([sut isPending]) should] beNo];
+                    [[theValue([sut isPendingActivation]) should] beNo];
                 });
             });
             context(@"when 'terminated'", ^{
@@ -206,12 +206,12 @@ context(@"given a Subscripion", ^{
                     
                 });
                 it(@"should return NO", ^{
-                    [[theValue([sut isPending]) should] beNo];
+                    [[theValue([sut isPendingActivation]) should] beNo];
                 });
             });
         });
         describe(@"isActive", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut isActive]) should] beNo];
                 });
@@ -245,7 +245,7 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"isSuspended", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut isSuspended]) should] beNo];
                 });
@@ -279,7 +279,7 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"isTerminated", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut isTerminated]) should] beNo];
                 });
@@ -316,7 +316,7 @@ context(@"given a Subscripion", ^{
     
     describe(@"checking if an event will trigger a valid transition", ^{
         describe(@"canActivate", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return YES", ^{
                     [[theValue([sut canActivate]) should] beYes];
                 });
@@ -350,7 +350,7 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"canSuspend", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut canSuspend]) should] beNo];
                 });
@@ -384,7 +384,7 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"canUnsuspend", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut canUnsuspend]) should] beNo];
                 });
@@ -418,7 +418,7 @@ context(@"given a Subscripion", ^{
             });
         });
         describe(@"canTerminate", ^{
-            context(@"when 'pending'", ^{
+            context(@"when 'pendingActivation'", ^{
                 it(@"should return NO", ^{
                     [[theValue([sut canTerminate]) should] beNo];
                 });
@@ -455,7 +455,7 @@ context(@"given a Subscripion", ^{
     describe(@"before callbacks", ^{
         describe(@"set terminatedAt", ^{
             describe(@"activate", ^{
-                describe(@"from 'pending'", ^{
+                describe(@"from 'pendingActivation'", ^{
                     it(@"should not set 'terminatedAt'", ^{
                         [sut activate];
                         
@@ -518,7 +518,7 @@ context(@"given a Subscripion", ^{
     describe(@"after callbacks", ^{
         describe(@"call stopBilling", ^{
             describe(@"activate", ^{
-                describe(@"from 'pending'", ^{
+                describe(@"from 'pendingActivation'", ^{
                     it(@"should not call stopBillin'", ^{
                         [[[sut shouldNot] receive] stopBilling];
                         


### PR DESCRIPTION
Given a state name with capital letters in its midst, such as "pendingActivation", a properly spelled `isPendingActivation` method should be generated. Given an event name with an uppercase letter in its midst, such as "makeAdmin", a properly spelled `canMakeAdmin` method should be generated.
