### PR TITLE
User can provide callbacks when state is entered or exited.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios
 
 target :StateMachineTests, :exclusive => true do
-   pod 'Kiwi', '~> 1.1.0'
+   pod 'Kiwi', '~> 1.1.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,10 @@
 PODS:
-  - Kiwi (1.1.0)
+  - Kiwi (1.1.1)
 
 DEPENDENCIES:
-  - Kiwi (~> 1.1.0)
+  - Kiwi (~> 1.1.1)
+
+SPEC CHECKSUMS:
+  Kiwi: ab0fa8d13b97dca05915e31df9b2d888d74ab717
+
+COCOAPODS: 0.23.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library was inspired by the Ruby gem [state_machine](https://github.com/plu
 ### As a [CocoaPod](http://cocoapods.org/)
 Just add this to your Podfile
 ```ruby
-pod 'StateMachine', '~> 0.1'
+pod 'StateMachine'
 ```
 
 ### Other approaches
@@ -35,6 +35,8 @@ At this moment you are responsible of defining a state property like this. In th
 
 @property (nonatomic, retain) NSDate *terminatedAt;
 - (void) stopBilling;
+- (void) startSendingProduct;
+- (void) stopSendingProduct;
 @end
 ```
 
@@ -68,6 +70,15 @@ STATE_MACHINE(^(LSStateMachine *sm) {
     [sm after:@"suspend" do:^(Subscription *subscription) {
         [subscription stopBilling];
     }];
+
+    [sm entering:@"active" do:^(Subscription *subscription) {
+        [subscription startSendingProduct];
+    }];
+
+    [sm exiting:@"active" do:^(Subscription *subscription) {
+        [subscription stopSendingProduct];
+    }];
+
 });
 
 - (id)init {
@@ -80,6 +91,14 @@ STATE_MACHINE(^(LSStateMachine *sm) {
 
 - (void) stopBilling {
     // Yeah, sure...
+}
+
+- (void) startSendingProduct {
+    // tell fulfillment department to start
+}
+
+- (void) stopSendingProduct {
+    // tell fulfillment department to stop
 }
 
 @end

--- a/StateMachine.podspec
+++ b/StateMachine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "StateMachine"
-  s.version      = "0.1"
+  s.version      = "0.2"
   s.summary      = "State machine library for Objective-C."
   s.homepage     = "https://github.com/luisobo/StateMachine"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Luis Solano Bonet" => "contact@luissolano.com" }
   # Specify the location from where the source should be retreived.
   #
-  s.source       = { :git => "https://github.com/luisobo/StateMachine.git", :tag => "0.1" }
+  s.source       = { :git => "https://github.com/luisobo/StateMachine.git", :tag => "0.2" }
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'

--- a/StateMachine/LSEvent.h
+++ b/StateMachine/LSEvent.h
@@ -15,7 +15,7 @@
 + (id)eventWithName:(NSString *)name
         transitions:(NSSet *)transitions
     beforeCallbacks:(NSArray *)beforeCallbacks
-    afterCallbacks:(NSArray *)afterCallbacks;
+     afterCallbacks:(NSArray *)afterCallbacks;
 
 - (id)initWithName:(NSString *)name
        transitions:(NSSet *)transitions

--- a/StateMachine/LSStateMachine.h
+++ b/StateMachine/LSStateMachine.h
@@ -6,13 +6,19 @@
 @interface LSStateMachine : NSObject
 @property (nonatomic, strong, readonly) NSSet *states;
 @property (nonatomic, strong, readonly) NSSet *events;
+@property (nonatomic, strong, readonly) NSDictionary *enteringCallbacks;
+@property (nonatomic, strong, readonly) NSDictionary *exitingCallbacks;
+
 @property (nonatomic, strong) NSString *initialState;
+
 - (void)addState:(NSString *)state;
 - (void)when:(NSString *)eventName transitionFrom:(NSString *)from to:(NSString *)to;
 - (LSEvent *)eventWithName:(NSString *)name;
 
 - (void)before:(NSString *)eventName do:(LSStateMachineTransitionCallback)callback;
 - (void)after:(NSString *)eventName do:(LSStateMachineTransitionCallback)callback;
+- (void)entering:(NSString *)state do:(LSStateMachineTransitionCallback)callback;
+- (void)exiting:(NSString *)state do:(LSStateMachineTransitionCallback)callback;
 
 - (NSString *)nextStateFrom:(NSString *)from forEvent:(NSString *)event;
 

--- a/StateMachine/LSStateMachine.m
+++ b/StateMachine/LSStateMachine.m
@@ -12,13 +12,18 @@ void * LSStateMachineDefinitionKey = &LSStateMachineDefinitionKey;
 @interface LSStateMachine ()
 @property (nonatomic, strong) NSMutableSet *mutableStates;
 @property (nonatomic, strong) NSMutableSet *mutableEvents;
+@property (nonatomic, strong) NSMutableDictionary *mutableEnteringCallbacks;
+@property (nonatomic, strong) NSMutableDictionary *mutableExitingCallbacks;
 @end
+
 @implementation LSStateMachine
 - (id)init {
     self = [super init];
     if (self) {
         _mutableStates = [[NSMutableSet alloc] init];
         _mutableEvents = [[NSMutableSet alloc] init];
+        _mutableEnteringCallbacks = [[NSMutableDictionary alloc] init];
+        _mutableExitingCallbacks = [[NSMutableDictionary alloc] init];
     }
     return self;
 }
@@ -65,12 +70,28 @@ void * LSStateMachineDefinitionKey = &LSStateMachineDefinitionKey;
     [self.mutableEvents addObject:newEvent];
 }
 
+- (void)entering:(NSString *)state do:(LSStateMachineTransitionCallback)callback {
+    self.mutableEnteringCallbacks[state] = callback;
+}
+
+- (void)exiting:(NSString *)state do:(LSStateMachineTransitionCallback)callback {
+    self.mutableExitingCallbacks[state] = callback;
+}
+
 - (NSSet *)states {
     return [NSSet setWithSet:self.mutableStates];
 }
 
 - (NSSet *)events {
     return [NSSet setWithSet:self.mutableEvents];
+}
+
+- (NSDictionary *)enteringCallbacks {
+    return [NSDictionary dictionaryWithDictionary:self.mutableEnteringCallbacks];
+}
+
+- (NSDictionary *)exitingCallbacks {
+    return [NSDictionary dictionaryWithDictionary:self.mutableExitingCallbacks];
 }
 
 - (void)setInitialState:(NSString *)defaultState {

--- a/StateMachine/LSStateMachineDynamicAdditions.m
+++ b/StateMachine/LSStateMachineDynamicAdditions.m
@@ -21,7 +21,18 @@ BOOL LSStateMachineTriggerEvent(id self, SEL _cmd) {
         for (void(^beforeCallback)(id) in beforeCallbacks) {
             beforeCallback(self);
         }
+
+        void (^exitingCallback)(id) = sm.exitingCallbacks[currentState];
+        if (exitingCallback) {
+            exitingCallback(self);
+        }
+        
         [self performSelector:@selector(setState:) withObject:nextState];
+        
+        void (^enteringCallback)(id) = sm.enteringCallbacks[nextState];
+        if (enteringCallback) {
+            enteringCallback(self);
+        }
         
         NSArray *afterCallbacks = event.afterCallbacks;
         for (LSStateMachineTransitionCallback afterCallback in afterCallbacks) {

--- a/StateMachineTests/StateMachineSpec.m
+++ b/StateMachineTests/StateMachineSpec.m
@@ -5,6 +5,8 @@
 @property (nonatomic, retain) NSString *state;
 @property (nonatomic, retain) NSDate *terminatedAt;
 - (void) stopBilling;
+- (void) startSendingProduct;
+- (void) stopSendingProduct;
 @end
 
 @interface Subscription (State)
@@ -47,6 +49,15 @@ STATE_MACHINE(^(LSStateMachine *sm) {
     [sm after:@"suspend" do:^(Subscription *subscription) {
         [subscription stopBilling];
     }];
+    
+    [sm entering:@"active" do:^(Subscription *subscription) {
+        [subscription startSendingProduct];
+    }];
+    
+    [sm exiting:@"active" do:^(Subscription *subscription) {
+        [subscription stopSendingProduct];
+    }];
+    
 });
 
 - (id)init {
@@ -59,6 +70,14 @@ STATE_MACHINE(^(LSStateMachine *sm) {
 
 - (void) stopBilling {
     // Yeah, sure...
+}
+
+- (void) startSendingProduct {
+    // tell fulfillment department to start
+}
+
+- (void) stopSendingProduct {
+    // tell fulfillment department to stop
 }
 
 @end
@@ -569,6 +588,130 @@ context(@"given a Subscripion", ^{
                     });
                     it(@"should not call stopBilling", ^{
                         [[[sut shouldNot] receive] stopBilling];
+                        
+                        [sut terminate];
+                    });
+                });
+            });
+        });
+    });
+
+    
+    describe(@"entering callbacks", ^{
+        describe(@"call startSendingProduct", ^{
+            describe(@"activate", ^{
+                describe(@"from 'pending'", ^{
+                    it(@"should call startSendingProduct'", ^{
+                        [[[sut should] receive] startSendingProduct];
+                        
+                        [sut activate];
+                    });
+                });
+            });
+            describe(@"suspend", ^{
+                describe(@"from 'active'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                    });
+                    it(@"should not call startSendingProduct", ^{
+                        [[[sut shouldNot] receive] startSendingProduct];
+                        
+                        [sut suspend];
+                    });
+                });
+            });
+            describe(@"unsuspend", ^{
+                describe(@"from 'suspended'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                        [sut suspend];
+                    });
+                    it(@"should call startSendingProduct", ^{
+                        [[[sut should] receive] startSendingProduct];
+                        
+                        [sut unsuspend];
+                    });
+                });
+            });
+            describe(@"terminate", ^{
+                describe(@"from'active'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                    });
+                    it(@"should not call startSendingProduct", ^{
+                        [[[sut shouldNot] receive] startSendingProduct];                        
+                        [sut terminate];
+                    });
+                });
+                describe(@"from 'suspended'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                        [sut suspend];
+                    });
+                    it(@"should not call startSendingProduct", ^{
+                        [[[sut shouldNot] receive] startSendingProduct];
+                        
+                        [sut terminate];
+                    });
+                });
+            });
+        });
+    });
+
+    describe(@"exiting callbacks", ^{
+        describe(@"call stopSendingProduct", ^{
+            describe(@"activate", ^{
+                describe(@"from 'pending'", ^{
+                    it(@"should not call startSendingProduct'", ^{
+                        [[[sut shouldNot] receive] stopSendingProduct];
+                        
+                        [sut activate];
+                    });
+                });
+            });
+            describe(@"suspend", ^{
+                describe(@"from 'active'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                    });
+                    it(@"should call stopSendingProduct", ^{
+                        [[[sut should] receive] stopSendingProduct];
+                        
+                        [sut suspend];
+                    });
+                });
+            });
+            describe(@"unsuspend", ^{
+                describe(@"from 'suspended'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                        [sut suspend];
+                    });
+                    it(@"should not call stopSendingProduct", ^{
+                        [[[sut shouldNot] receive] stopSendingProduct];
+                        
+                        [sut unsuspend];
+                    });
+                });
+            });
+            describe(@"terminate", ^{
+                describe(@"from'active'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                    });
+                    it(@"should call stopSendingProduct", ^{
+                        [[[sut should] receive] stopSendingProduct];
+                        
+                        [sut terminate];
+                    });
+                });
+                describe(@"from 'suspended'", ^{
+                    beforeEach(^{
+                        [sut activate];
+                        [sut suspend];
+                    });
+                    it(@"should not call stopSendingProduct", ^{
+                        [[[sut shouldNot] receive] stopSendingProduct];
                         
                         [sut terminate];
                     });


### PR DESCRIPTION
I wanted to be able to run a block whenever a state was entered or exited. So I added a couple of methods to the public interface:
- Added `[LSMStateMachine entering:do:]` and `[LSMStateMachine exiting:do:]`. E.g.,

``` Objective-C
              [sm entering:@"state" do:^(LSStateMachine *sm) {
                   // this code runs whenever @"state" is entered
              }] 

              [sm exiting:@"state" do:^(LSStateMachine *sm) {
                   // this code runs whenever @"state" is exited
              }]
```
- Added tests
- Updated Kiwi to version 1.1.1 (1.1.0 spec had a bug.  See: https://github.com/CocoaPods/Specs/pull/245)
- Added examples to README.md
## TODO:
- Submit StateMachine.podspec to Cocoapods repo.
